### PR TITLE
- java bot example: suppress cleanupDaemonThreads error

### DIFF
--- a/bot-example/java/pom.xml
+++ b/bot-example/java/pom.xml
@@ -36,6 +36,7 @@
                 <version>3.0.0</version>
                 <configuration>
                     <mainClass>org.example.Main</mainClass>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Removes error which can occur on program finish:
thanks to @iPenkinDev

![image](https://github.com/bot-games/drones/assets/2398460/89854587-5770-418b-96dc-f32021a697a2)
